### PR TITLE
Update OpenRPC JSON

### DIFF
--- a/scripts/openrpc-json-updater/modified-openrpc.json
+++ b/scripts/openrpc-json-updater/modified-openrpc.json
@@ -57,9 +57,12 @@
         "name": "Accounts",
         "description": "Always returns an empty array",
         "schema": {
-          "title": "empty array",
+          "title": "Accounts",
           "type": "array",
-          "pattern": "^\\[\\s*\\]$"
+          "pattern": "^\\[\\s*\\]$",
+          "items": {
+            "$ref": "#/components/schemas/address"
+          }
         }
       }
     },
@@ -77,21 +80,21 @@
     },
     {
       "name": "eth_call",
-      "summary": "Executes a new message call immediately without creating a transaction on the block chain. ",
+      "summary": "Executes a new message call immediately without creating a transaction on the block chain.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
           "name": "Transaction",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/TransactionWithSender"
+            "$ref": "#/components/schemas/GenericTransaction"
           }
         },
         {
           "name": "Block",
           "required": false,
           "schema": {
-            "$ref": "#/components/schemas/BlockNumberOrTag"
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
         }
       ],
@@ -116,18 +119,27 @@
     },
     {
       "name": "eth_coinbase",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
+      "summary": "Returns the client coinbase address.",
       "params": [],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Coinbase address",
+        "schema": {
+          "$ref": "#/components/schemas/address"
+        }
       }
     },
     {
       "name": "eth_blobBaseFee",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
+      "summary": "Returns the base fee per blob gas in wei.",
       "params": [],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Blob gas base fee",
+        "schema": {
+          "title": "Blob gas base fee",
+          "$ref": "#/components/schemas/uint"
+        }
       }
     },
     {
@@ -139,7 +151,7 @@
           "name": "Transaction",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/TransactionWithSender"
+            "$ref": "#/components/schemas/GenericTransaction"
           }
         },
         {
@@ -159,8 +171,8 @@
     },
     {
       "name": "eth_feeHistory",
-      "summary": "Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.",
-      "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
+      "summary": "Transaction fee history",
+      "description": "Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.",
       "params": [
         {
           "name": "blockCount",
@@ -180,7 +192,7 @@
         },
         {
           "name": "rewardPercentiles",
-          "description": "A monotonically increasing list of percentile values. For each block in the requested range, the transactions will be sorted in ascending order by effective tip per gas and the coresponding effective tip for the percentile will be determined, accounting for gas consumed.",
+          "description": "A monotonically increasing list of percentile values. For each block in the requested range, the transactions will be sorted in ascending order by effective tip per gas and the corresponding effective tip for the percentile will be determined, accounting for gas consumed.",
           "required": true,
           "schema": {
             "title": "rewardPercentiles",
@@ -195,7 +207,7 @@
         }
       ],
       "result": {
-        "name": "feeHistoryResult",
+        "name": "Fee history result",
         "description": "Fee history for the returned block range. This can be a subsection of the requested range if not all blocks are available.",
         "schema": {
           "title": "feeHistoryResults",
@@ -210,24 +222,25 @@
             },
             "gasUsedRatio": {
               "title": "gasUsedRatio",
-              "description": "An array of gas used ratio.",
+              "description": "An array of block gas used ratios. These are calculated as the ratio of gasUsed and gasLimit.",
               "type": "array",
               "items": {
                 "title": "floating point number",
                 "type": "number",
-                "pattern": "^([0-9].[0-9]*|0)$"
+                "pattern": "^([0-9].[0-9]*|0)$",
+                "$ref": "#/components/schemas/ratio"
               }
             },
             "baseFeePerGas": {
-              "title": "baseFeePerGas",
-              "description": "An array of block base fees per gas. This includes the next block after the newest of the returned range.",
+              "title": "baseFeePerGasArray",
+              "description": "An array of block base fees per gas. This includes the next block after the newest of the returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559 blocks.",
               "type": "array",
               "items": {
                 "$ref": "#/components/schemas/uint"
               }
             },
             "reward": {
-              "title": "reward",
+              "title": "rewardArray",
               "description": "A two-dimensional array of effective priority fees per gas at the requested block percentiles.",
               "type": "array",
               "items": {
@@ -241,13 +254,14 @@
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },
     {
       "name": "eth_gasPrice",
-      "summary": "Returns the current price per gas in weibars.",
+      "summary": "Returns the current price per gas in wei.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [],
       "result": {
@@ -272,9 +286,9 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
-            "$ref": "#/components/schemas/BlockNumberOrTag"
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
         }
       ],
@@ -310,7 +324,15 @@
       "result": {
         "name": "Block information",
         "schema": {
-          "$ref": "#/components/schemas/Block"
+          "$ref": "#/components/schemas/Block",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/Block"
+            }
+          ]
         }
       }
     },
@@ -338,7 +360,15 @@
       "result": {
         "name": "Block information",
         "schema": {
-          "$ref": "#/components/schemas/Block"
+          "$ref": "#/components/schemas/Block",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/Block"
+            }
+          ]
         }
       }
     },
@@ -355,9 +385,18 @@
         }
       ],
       "result": {
-        "name": "Transactions count",
+        "name": "Transaction count",
         "schema": {
-          "$ref": "#/components/schemas/uint"
+          "$ref": "#/components/schemas/uint",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "title": "Transaction count",
+              "$ref": "#/components/schemas/uint"
+            }
+          ]
         }
       }
     },
@@ -374,9 +413,18 @@
         }
       ],
       "result": {
-        "name": "Transactions count",
+        "name": "Transaction count",
         "schema": {
-          "$ref": "#/components/schemas/uint"
+          "$ref": "#/components/schemas/uint",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "title": "Transaction count",
+              "$ref": "#/components/schemas/uint"
+            }
+          ]
         }
       }
     },
@@ -394,9 +442,9 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
-            "$ref": "#/components/schemas/BlockNumberOrTag"
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
         }
       ],
@@ -409,7 +457,7 @@
     },
     {
       "name": "eth_getLogs",
-      "summary": "Returns an array of all logs matching a given filter object.",
+      "summary": "Returns an array of all logs matching the specified filter.",
       "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted. In any case, if the `topics` param is present the block range must be within ~`302,400` blocks, the equivalent to 7 days.\n\nWhen the logs for an individual address exceeds `MIRROR_NODE_CONTRACT_RESULTS_LOGS_PG_MAX * MIRROR_NODE_LIMIT_PARAM` (defaults to `20k`) an error `-32011` _Mirror Node pagination count range too large_ is returned. These settings are the Mirror Node page limit (defaults to `200`) and Mirror Node entries per page (defaults to `100`) respectively. ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
@@ -428,7 +476,7 @@
     },
     {
       "name": "eth_getStorageAt",
-      "summary": "Returns the value from a storage position at a given address and block. The optional block param may be latest or a valid tag of a historical block.",
+      "summary": "Returns the value from a storage position at a given address.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
@@ -439,24 +487,24 @@
           }
         },
         {
-          "name": "Position",
+          "name": "Storage slot",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/uint"
+            "$ref": "#/components/schemas/bytesMax32"
           }
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
         }
       ],
       "result": {
-        "name": "Value from storage",
+        "name": "Value",
         "schema": {
-          "$ref": "#/components/schemas/hash32"
+          "$ref": "#/components/schemas/bytes"
         }
       }
     },
@@ -483,7 +531,15 @@
       "result": {
         "name": "Transaction information",
         "schema": {
-          "$ref": "#/components/schemas/TransactionInfo"
+          "$ref": "#/components/schemas/TransactionInfo",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/TransactionInfo"
+            }
+          ]
         }
       }
     },
@@ -510,7 +566,15 @@
       "result": {
         "name": "Transaction information",
         "schema": {
-          "$ref": "#/components/schemas/TransactionInfo"
+          "$ref": "#/components/schemas/TransactionInfo",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/TransactionInfo"
+            }
+          ]
         }
       }
     },
@@ -530,13 +594,21 @@
       "result": {
         "name": "Transaction information",
         "schema": {
-          "$ref": "#/components/schemas/TransactionInfo"
+          "$ref": "#/components/schemas/TransactionInfo",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/TransactionInfo"
+            }
+          ]
         }
       }
     },
     {
       "name": "eth_getTransactionCount",
-      "summary": "Returns the number of transactions sent from an address.",
+      "summary": "Returns the nonce of an account in the state. NOTE: The name eth_getTransactionCount reflects the historical fact that an account's nonce and sent transaction count were the same. After the Pectra fork, with the inclusion of EIP-7702, this is no longer true.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
@@ -548,14 +620,14 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
-            "$ref": "#/components/schemas/BlockNumberOrTag"
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
         }
       ],
       "result": {
-        "name": "Transaction count",
+        "name": "Account nonce",
         "schema": {
           "title": "Transaction count",
           "$ref": "#/components/schemas/uint"
@@ -575,9 +647,17 @@
         }
       ],
       "result": {
-        "name": "Receipt Information",
+        "name": "Receipt information",
         "schema": {
-          "$ref": "#/components/schemas/ReceiptInfo"
+          "$ref": "#/components/schemas/ReceiptInfo",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "$ref": "#/components/schemas/ReceiptInfo"
+            }
+          ]
         }
       }
     },
@@ -611,14 +691,30 @@
       "name": "eth_getUncleCountByBlockHash",
       "summary": "Returns the number of uncles in a block from a block matching the given block hash.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
-      "params": [],
+      "params": [
+        {
+          "name": "Block hash",
+          "schema": {
+            "$ref": "#/components/schemas/hash32"
+          }
+        }
+      ],
       "result": {
-        "name": "eth_getUncleCountByBlockHash result",
+        "name": "Uncle count",
         "schema": {
           "description": "Always returns '0x0'. There are no uncles in Hedera.",
           "title": "hex encoded unsigned integer",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "0x0",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "title": "Uncle count",
+              "$ref": "#/components/schemas/uint"
+            }
+          ]
         }
       }
     },
@@ -626,14 +722,30 @@
       "name": "eth_getUncleCountByBlockNumber",
       "summary": "Returns the number of transactions in a block matching the given block number.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
-      "params": [],
+      "params": [
+        {
+          "name": "Block",
+          "schema": {
+            "$ref": "#/components/schemas/BlockNumberOrTag"
+          }
+        }
+      ],
       "result": {
-        "name": "eth_getUncleCountByBlockNumber result",
+        "name": "Uncle count",
         "schema": {
           "description": "Always returns '0x0'. There are no uncles in Hedera.",
           "title": "hex encoded unsigned integer",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "0x0",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "title": "Uncle count",
+              "$ref": "#/components/schemas/uint"
+            }
+          ]
         }
       }
     },
@@ -661,16 +773,17 @@
     },
     {
       "name": "eth_maxPriorityFeePerGas",
-      "summary": "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block.",
+      "summary": "Returns the current maxPriorityFeePerGas per gas in wei.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [],
       "result": {
-        "name": "eth_maxPriorityFeePerGas result",
+        "name": "Max priority fee per gas",
         "schema": {
           "description": "Always returns '0x0'. Hedera doesn't have a concept of tipping nodes to promote any behavior",
-          "title": "hex encoded unsigned integer",
+          "title": "Max priority fee per gas",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "0x0",
+          "$ref": "#/components/schemas/uint"
         }
       }
     },
@@ -689,13 +802,13 @@
     },
     {
       "name": "eth_newBlockFilter",
-      "summary": "Creates a filter object, to notify of newly created blocks.",
+      "summary": "Creates a filter in the node, to notify when a new block arrives.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [],
       "result": {
-        "name": "Filter ID",
+        "name": "Filter identifier",
         "schema": {
-          "$ref": "#/components/schemas/hash16"
+          "$ref": "#/components/schemas/uint"
         }
       },
       "tags": [
@@ -710,16 +823,16 @@
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
-          "name": "LogFilter",
+          "name": "Filter",
           "schema": {
-            "$ref": "#/components/schemas/LogFilter"
+            "$ref": "#/components/schemas/Filter"
           }
         }
       ],
       "result": {
-        "name": "Filter ID",
+        "name": "Filter identifier",
         "schema": {
-          "$ref": "#/components/schemas/hash16"
+          "$ref": "#/components/schemas/uint"
         }
       },
       "tags": [
@@ -734,14 +847,14 @@
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "FilterID",
+          "name": "Filter identifier",
           "schema": {
-            "$ref": "#/components/schemas/hash16"
+            "$ref": "#/components/schemas/uint"
           }
         }
       ],
       "result": {
-        "name": "Uninstall status",
+        "name": "Success",
         "schema": {
           "type": "boolean"
         }
@@ -754,10 +867,14 @@
     },
     {
       "name": "eth_newPendingTransactionFilter",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
+      "summary": "Creates a filter in the node, to notify when new pending transactions arrive.",
       "params": [],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Filter identifier",
+        "schema": {
+          "$ref": "#/components/schemas/uint"
+        }
       },
       "tags": [
         {
@@ -767,18 +884,18 @@
     },
     {
       "name": "eth_getFilterLogs",
-      "summary": "Returns an array of all logs matching filter with given id.",
+      "summary": "Returns an array of all logs matching the filter with the given ID (created using `eth_newFilter`).",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "Filter ID",
+          "name": "Filter identifier",
           "schema": {
-            "$ref": "#/components/schemas/hash16"
+            "$ref": "#/components/schemas/uint"
           }
         }
       ],
       "result": {
-        "name": "Filter result",
+        "name": "Log objects",
         "schema": {
           "$ref": "#/components/schemas/FilterResults"
         }
@@ -791,18 +908,18 @@
     },
     {
       "name": "eth_getFilterChanges",
-      "summary": "Gets the latest results since the last request for a provided filter according to its type.",
+      "summary": "Polling method for the filter with the given ID (created using `eth_newFilter`). Returns an array of logs which occurred since last poll.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "Filter ID",
+          "name": "Filter identifier",
           "schema": {
-            "$ref": "#/components/schemas/hash16"
+            "$ref": "#/components/schemas/uint"
           }
         }
       ],
       "result": {
-        "name": "Filter result",
+        "name": "Log objects",
         "schema": {
           "oneOf": [
             {
@@ -820,7 +937,8 @@
                 "$ref": "#/components/schemas/FilterResults"
               }
             }
-          ]
+          ],
+          "$ref": "#/components/schemas/FilterResults"
         }
       },
       "tags": [
@@ -839,7 +957,7 @@
     },
     {
       "name": "eth_sendRawTransaction",
-      "summary": "Submits a raw transaction.",
+      "summary": "Submits a raw transaction. You can create and sign a transaction externally using a library such as [web3.js](https://web3js.readthedocs.io/) or [ethers.js](https://docs.ethers.org/). For [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) transactions, the raw form must be the network form. This means it includes the blobs, KZG commitments, and KZG proofs. For [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594) transactions, the raw format must be the network form. This means it includes the blobs, KZG commitments, and cell proofs. The logic for handling the new transaction during fork boundaries are 1. When receiving an encoded transaction with cell proofs before the PeerDAS fork activates, we reject it. Only blob proofs are accepted into the pool. 2. At the time of fork activation, the implementer could (not mandatory) - Drop all old-format transactions - Convert old proofs to new format (computationally expensive) - Convert only when including in a locally produced block 3. After the fork has activated, only txs with cell proofs are accepted via p2p relay. 4. On RPC (eth_sendRawTransaction), txs with blob proofs may still be accepted and will be auto-converted by the node. At implementer discretion, this facility can be deprecated later when users have switched to new client libraries that can create cell proofs.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
@@ -859,26 +977,69 @@
     },
     {
       "name": "eth_sendTransaction",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Signs and submits a transaction.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/GenericTransaction"
+          }
+        }
+      ],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Transaction hash",
+        "schema": {
+          "$ref": "#/components/schemas/hash32"
+        }
       }
     },
     {
       "name": "eth_signTransaction",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns an RLP encoded transaction signed by the specified account.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/GenericTransaction"
+          }
+        }
+      ],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Encoded transaction",
+        "schema": {
+          "$ref": "#/components/schemas/bytes"
+        }
       }
     },
     {
       "name": "eth_sign",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns an EIP-191 signature over the provided data.",
+      "params": [
+        {
+          "name": "Address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/address"
+          }
+        },
+        {
+          "name": "Message",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/bytes"
+          }
+        }
+      ],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Signature",
+        "schema": {
+          "$ref": "#/components/schemas/bytes65"
+        }
       }
     },
     {
@@ -905,7 +1066,7 @@
     },
     {
       "name": "eth_syncing",
-      "summary": "Returns syncing status.",
+      "summary": "Returns an object with data about the sync status or false.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [],
       "result": {
@@ -913,7 +1074,8 @@
         "schema": {
           "title": "Not syncing",
           "description": "Always returns false.",
-          "type": "boolean"
+          "type": "boolean",
+          "$ref": "#/components/schemas/SyncingStatus"
         }
       }
     },
@@ -1239,10 +1401,112 @@
     },
     {
       "name": "eth_getProof",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns the merkle proof for a given account and optionally some storage keys.",
+      "params": [
+        {
+          "name": "Address",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/address"
+          }
+        },
+        {
+          "name": "StorageKeys",
+          "required": true,
+          "schema": {
+            "title": "Storage keys",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytesMax32"
+            }
+          }
+        },
+        {
+          "name": "Block",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
+          }
+        }
+      ],
       "result": {
-        "$ref": "#/components/schemas/unsupportedError"
+        "$ref": "#/components/schemas/unsupportedError",
+        "name": "Account",
+        "schema": {
+          "$ref": "#/components/schemas/AccountProof"
+        }
+      }
+    },
+    {
+      "name": "eth_createAccessList",
+      "summary": "Generates an access list for a transaction.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/GenericTransaction"
+          }
+        },
+        {
+          "name": "Block",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/BlockNumberOrTag"
+          }
+        }
+      ],
+      "result": {
+        "name": "Gas used",
+        "schema": {
+          "title": "Access list result",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accessList": {
+              "title": "accessList",
+              "$ref": "#/components/schemas/AccessList"
+            },
+            "error": {
+              "title": "error",
+              "type": "string"
+            },
+            "gasUsed": {
+              "title": "Gas used",
+              "$ref": "#/components/schemas/uint"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "eth_getBlockReceipts",
+      "summary": "Returns the receipts of a block by number or hash.",
+      "params": [
+        {
+          "name": "Block",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
+          }
+        }
+      ],
+      "result": {
+        "name": "Receipts information",
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/notFound"
+            },
+            {
+              "title": "Receipts information",
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ReceiptInfo"
+              }
+            }
+          ]
+        }
       }
     }
   ],
@@ -2163,6 +2427,1170 @@
           }
         },
         "required": ["from", "gas", "input"]
+      },
+      "bytesMax32": {
+        "title": "32 hex encoded bytes",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{0,64}$"
+      },
+      "bytes48": {
+        "title": "48 hex encoded bytes",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{96}$"
+      },
+      "bytes96": {
+        "title": "96 hex encoded bytes",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{192}$"
+      },
+      "ratio": {
+        "title": "normalized ratio",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "uint64": {
+        "title": "hex encoded 64 bit unsigned integer",
+        "type": "string",
+        "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,15})$"
+      },
+      "notFound": {
+        "title": "Not Found (null)",
+        "type": "null"
+      },
+      "BadBlock": {
+        "title": "Bad block",
+        "type": "object",
+        "required": ["block", "hash", "rlp"],
+        "additionalProperties": false,
+        "properties": {
+          "block": {
+            "title": "Block",
+            "$ref": "#/components/schemas/Block"
+          },
+          "hash": {
+            "title": "Hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "rlp": {
+            "title": "RLP",
+            "$ref": "#/components/schemas/bytes"
+          }
+        }
+      },
+      "SyncingStatus": {
+        "title": "Syncing status",
+        "oneOf": [
+          {
+            "title": "Syncing progress",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "startingBlock": {
+                "title": "Starting block",
+                "$ref": "#/components/schemas/uint"
+              },
+              "currentBlock": {
+                "title": "Current block",
+                "$ref": "#/components/schemas/uint"
+              },
+              "highestBlock": {
+                "title": "Highest block",
+                "$ref": "#/components/schemas/uint"
+              }
+            }
+          },
+          {
+            "title": "Not syncing",
+            "description": "Should always return false if not syncing.",
+            "type": "boolean"
+          }
+        ]
+      },
+      "AccountProof": {
+        "title": "Account proof",
+        "type": "object",
+        "required": ["address", "accountProof", "balance", "codeHash", "nonce", "storageHash", "storageProof"],
+        "additionalProperties": false,
+        "properties": {
+          "address": {
+            "title": "address",
+            "$ref": "#/components/schemas/address"
+          },
+          "accountProof": {
+            "title": "accountProof",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          },
+          "balance": {
+            "title": "balance",
+            "$ref": "#/components/schemas/uint256"
+          },
+          "codeHash": {
+            "title": "codeHash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "nonce": {
+            "title": "nonce",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "storageHash": {
+            "title": "storageHash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "storageProof": {
+            "title": "Storage proofs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StorageProof"
+            }
+          }
+        }
+      },
+      "StorageProof": {
+        "title": "Storage proof",
+        "type": "object",
+        "required": ["key", "value", "proof"],
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "title": "key",
+            "$ref": "#/components/schemas/bytesMax32"
+          },
+          "value": {
+            "title": "value",
+            "$ref": "#/components/schemas/uint256"
+          },
+          "proof": {
+            "title": "proof",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          }
+        }
+      },
+      "Transaction7702Unsigned": {
+        "type": "object",
+        "title": "EIP-7702 transaction",
+        "required": [
+          "type",
+          "nonce",
+          "to",
+          "gas",
+          "value",
+          "input",
+          "maxPriorityFeePerGas",
+          "maxFeePerGas",
+          "accessList",
+          "chainId",
+          "authorizationList"
+        ],
+        "properties": {
+          "type": {
+            "title": "type",
+            "type": "string",
+            "pattern": "^0x4$"
+          },
+          "nonce": {
+            "title": "nonce",
+            "$ref": "#/components/schemas/uint"
+          },
+          "to": {
+            "title": "to address",
+            "$ref": "#/components/schemas/address"
+          },
+          "gas": {
+            "title": "gas limit",
+            "$ref": "#/components/schemas/uint"
+          },
+          "value": {
+            "title": "value",
+            "$ref": "#/components/schemas/uint"
+          },
+          "input": {
+            "title": "input data",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "maxPriorityFeePerGas": {
+            "title": "max priority fee per gas",
+            "description": "Maximum fee per gas the sender is willing to pay to miners in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxFeePerGas": {
+            "title": "max fee per gas",
+            "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "gasPrice": {
+            "title": "gas price",
+            "description": "The effective gas price paid by the sender in wei. For transactions not yet included in a block, this value should be set equal to the max fee per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.",
+            "$ref": "#/components/schemas/uint"
+          },
+          "accessList": {
+            "title": "accessList",
+            "description": "EIP-2930 access lists",
+            "$ref": "#/components/schemas/AccessList"
+          },
+          "chainId": {
+            "title": "chainId",
+            "description": "Chain ID that this transaction is valid on",
+            "$ref": "#/components/schemas/uint"
+          },
+          "authorizationList": {
+            "title": "authorizationList",
+            "$ref": "#/components/schemas/AuthorizationList"
+          }
+        }
+      },
+      "AuthorizationList": {
+        "title": "Authorization List",
+        "description": "List of authorizations for the transaction",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "chainId": {
+              "title": "chainId",
+              "description": "Chain ID on which this transaction is valid",
+              "$ref": "#/components/schemas/uint"
+            },
+            "nonce": {
+              "title": "nonce",
+              "$ref": "#/components/schemas/uint"
+            },
+            "address": {
+              "$ref": "#/components/schemas/address"
+            },
+            "yParity": {
+              "title": "yParity",
+              "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature",
+              "$ref": "#/components/schemas/byte"
+            },
+            "r": {
+              "title": "r",
+              "$ref": "#/components/schemas/uint256"
+            },
+            "s": {
+              "title": "s",
+              "$ref": "#/components/schemas/uint256"
+            }
+          },
+          "required": ["chainId", "nonce", "address", "yParity", "r", "s"]
+        }
+      },
+      "Transaction4844Unsigned": {
+        "type": "object",
+        "title": "EIP-4844 transaction.",
+        "required": [
+          "type",
+          "nonce",
+          "to",
+          "gas",
+          "value",
+          "input",
+          "maxPriorityFeePerGas",
+          "maxFeePerGas",
+          "maxFeePerBlobGas",
+          "accessList",
+          "blobVersionedHashes",
+          "chainId"
+        ],
+        "properties": {
+          "type": {
+            "title": "type",
+            "type": "string",
+            "pattern": "^0x3$"
+          },
+          "nonce": {
+            "title": "nonce",
+            "$ref": "#/components/schemas/uint"
+          },
+          "to": {
+            "title": "to address",
+            "$ref": "#/components/schemas/address"
+          },
+          "gas": {
+            "title": "gas limit",
+            "$ref": "#/components/schemas/uint"
+          },
+          "value": {
+            "title": "value",
+            "$ref": "#/components/schemas/uint"
+          },
+          "input": {
+            "title": "input data",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "maxPriorityFeePerGas": {
+            "title": "max priority fee per gas",
+            "description": "Maximum fee per gas the sender is willing to pay to miners in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxFeePerGas": {
+            "title": "max fee per gas",
+            "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxFeePerBlobGas": {
+            "title": "max fee per blob gas",
+            "description": "The maximum total fee per gas the sender is willing to pay for blob gas in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "gasPrice": {
+            "title": "gas price",
+            "description": "The effective gas price paid by the sender in wei. For transactions not yet included in a block, this value should be set equal to the max fee per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.",
+            "$ref": "#/components/schemas/uint"
+          },
+          "accessList": {
+            "title": "accessList",
+            "description": "EIP-2930 access list",
+            "$ref": "#/components/schemas/AccessList"
+          },
+          "blobVersionedHashes": {
+            "title": "blobVersionedHashes",
+            "description": "List of versioned blob hashes associated with the transaction's EIP-4844 data blobs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/hash32"
+            }
+          },
+          "chainId": {
+            "title": "chainId",
+            "description": "Chain ID that this transaction is valid on",
+            "$ref": "#/components/schemas/uint"
+          }
+        }
+      },
+      "AccessListEntry": {
+        "title": "Access list entry",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["address", "storageKeys"],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/address"
+          },
+          "storageKeys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/hash32"
+            }
+          }
+        }
+      },
+      "AccessList": {
+        "title": "Access list",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AccessListEntry"
+        }
+      },
+      "Transaction2930Unsigned": {
+        "type": "object",
+        "title": "EIP-2930 transaction.",
+        "required": ["type", "nonce", "gas", "value", "input", "gasPrice", "chainId", "accessList"],
+        "properties": {
+          "type": {
+            "title": "type",
+            "type": "string",
+            "pattern": "^0x1$"
+          },
+          "nonce": {
+            "title": "nonce",
+            "$ref": "#/components/schemas/uint"
+          },
+          "to": {
+            "title": "to address",
+            "oneOf": [
+              {
+                "title": "Contract Creation (null)",
+                "type": "null"
+              },
+              {
+                "title": "Address",
+                "$ref": "#/components/schemas/address"
+              }
+            ]
+          },
+          "gas": {
+            "title": "gas limit",
+            "$ref": "#/components/schemas/uint"
+          },
+          "value": {
+            "title": "value",
+            "$ref": "#/components/schemas/uint"
+          },
+          "input": {
+            "title": "input data",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "gasPrice": {
+            "title": "gas price",
+            "description": "The gas price willing to be paid by the sender in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "accessList": {
+            "title": "accessList",
+            "description": "EIP-2930 access list",
+            "$ref": "#/components/schemas/AccessList"
+          },
+          "chainId": {
+            "title": "chainId",
+            "description": "Chain ID that this transaction is valid on.",
+            "$ref": "#/components/schemas/uint"
+          }
+        }
+      },
+      "Transaction7702Signed": {
+        "title": "Signed 7702 Transaction",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction7702Unsigned"
+          },
+          {
+            "title": "EIP-7702 transaction signature properties.",
+            "required": ["yParity", "r", "s"],
+            "properties": {
+              "yParity": {
+                "title": "yParity",
+                "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "v": {
+                "title": "v",
+                "description": "For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "r": {
+                "title": "r",
+                "$ref": "#/components/schemas/uint"
+              },
+              "s": {
+                "title": "s",
+                "$ref": "#/components/schemas/uint"
+              }
+            }
+          }
+        ]
+      },
+      "Transaction4844Signed": {
+        "title": "Signed 4844 Transaction",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction4844Unsigned"
+          },
+          {
+            "title": "EIP-4844 transaction signature properties.",
+            "required": ["yParity", "r", "s"],
+            "properties": {
+              "yParity": {
+                "title": "yParity",
+                "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "v": {
+                "title": "v",
+                "description": "For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "r": {
+                "title": "r",
+                "$ref": "#/components/schemas/uint"
+              },
+              "s": {
+                "title": "s",
+                "$ref": "#/components/schemas/uint"
+              }
+            }
+          }
+        ]
+      },
+      "Transaction2930Signed": {
+        "title": "Signed 2930 Transaction",
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction2930Unsigned"
+          },
+          {
+            "title": "EIP-2930 transaction signature properties.",
+            "required": ["yParity", "r", "s"],
+            "properties": {
+              "yParity": {
+                "title": "yParity",
+                "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "v": {
+                "title": "v",
+                "description": "For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.",
+                "$ref": "#/components/schemas/byte"
+              },
+              "r": {
+                "title": "r",
+                "$ref": "#/components/schemas/uint"
+              },
+              "s": {
+                "title": "s",
+                "$ref": "#/components/schemas/uint"
+              }
+            }
+          }
+        ]
+      },
+      "GenericTransaction": {
+        "type": "object",
+        "title": "Transaction object generic to all types",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "title": "type",
+            "$ref": "#/components/schemas/byte"
+          },
+          "nonce": {
+            "title": "nonce",
+            "$ref": "#/components/schemas/uint"
+          },
+          "to": {
+            "title": "to address",
+            "oneOf": [
+              {
+                "title": "Contract Creation (null)",
+                "type": "null"
+              },
+              {
+                "title": "Address",
+                "$ref": "#/components/schemas/address"
+              }
+            ]
+          },
+          "from": {
+            "title": "from address",
+            "$ref": "#/components/schemas/address"
+          },
+          "gas": {
+            "title": "gas limit",
+            "$ref": "#/components/schemas/uint"
+          },
+          "value": {
+            "title": "value",
+            "$ref": "#/components/schemas/uint"
+          },
+          "input": {
+            "title": "input data",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "gasPrice": {
+            "title": "gas price",
+            "description": "The gas price willing to be paid by the sender in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxPriorityFeePerGas": {
+            "title": "max priority fee per gas",
+            "description": "Maximum fee per gas the sender is willing to pay to miners in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxFeePerGas": {
+            "title": "max fee per gas",
+            "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "maxFeePerBlobGas": {
+            "title": "max fee per blob gas",
+            "description": "The maximum total fee per gas the sender is willing to pay for blob gas in wei",
+            "$ref": "#/components/schemas/uint"
+          },
+          "accessList": {
+            "title": "accessList",
+            "description": "EIP-2930 access list",
+            "$ref": "#/components/schemas/AccessList"
+          },
+          "blobVersionedHashes": {
+            "title": "blobVersionedHashes",
+            "description": "List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/hash32"
+            }
+          },
+          "blobs": {
+            "title": "blobs",
+            "description": "Raw blob data.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          },
+          "chainId": {
+            "title": "chainId",
+            "description": "Chain ID that this transaction is valid on.",
+            "$ref": "#/components/schemas/uint"
+          },
+          "authorizationList": {
+            "title": "authorizationList",
+            "description": "EIP-7702 authorization list",
+            "$ref": "#/components/schemas/AuthorizationList"
+          }
+        }
+      },
+      "Withdrawal": {
+        "type": "object",
+        "title": "Validator withdrawal",
+        "required": ["index", "validatorIndex", "address", "amount"],
+        "additionalProperties": false,
+        "properties": {
+          "index": {
+            "title": "index of withdrawal",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "validatorIndex": {
+            "title": "index of validator that generated withdrawal",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "address": {
+            "title": "recipient address for withdrawal value",
+            "$ref": "#/components/schemas/address"
+          },
+          "amount": {
+            "title": "value contained in withdrawal",
+            "$ref": "#/components/schemas/uint256"
+          }
+        }
+      },
+      "BlobAndProofV1": {
+        "title": "Blob and proof object V1",
+        "type": "object",
+        "required": ["blob", "proof"],
+        "properties": {
+          "blob": {
+            "title": "Blob",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "proof": {
+            "title": "proof",
+            "$ref": "#/components/schemas/bytes48"
+          }
+        }
+      },
+      "BlobAndProofV2": {
+        "title": "Blob and proof object V2",
+        "type": "object",
+        "required": ["blob", "proofs"],
+        "properties": {
+          "blob": {
+            "title": "Blob",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "proofs": {
+            "title": "Cell Proofs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes48"
+            }
+          }
+        }
+      },
+      "ForkchoiceStateV1": {
+        "title": "Forkchoice state object V1",
+        "type": "object",
+        "required": ["headBlockHash", "safeBlockHash", "finalizedBlockHash"],
+        "properties": {
+          "headBlockHash": {
+            "title": "Head block hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "safeBlockHash": {
+            "title": "Safe block hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "finalizedBlockHash": {
+            "title": "Finalized block hash",
+            "$ref": "#/components/schemas/hash32"
+          }
+        }
+      },
+      "ForkchoiceUpdatedResponseV1": {
+        "title": "Forkchoice updated response",
+        "type": "object",
+        "required": ["payloadStatus"],
+        "properties": {
+          "payloadStatus": {
+            "title": "Payload status",
+            "$ref": "#/components/schemas/RestrictedPayloadStatusV1"
+          },
+          "payloadId": {
+            "title": "Payload id",
+            "$ref": "#/components/schemas/bytes8"
+          }
+        }
+      },
+      "PayloadAttributesV1": {
+        "title": "Payload attributes object V1",
+        "type": "object",
+        "required": ["timestamp", "prevRandao", "suggestedFeeRecipient"],
+        "properties": {
+          "timestamp": {
+            "title": "Timestamp",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "prevRandao": {
+            "title": "Previous randao value",
+            "$ref": "#/components/schemas/bytes32"
+          },
+          "suggestedFeeRecipient": {
+            "title": "Suggested fee recipient",
+            "$ref": "#/components/schemas/address"
+          }
+        }
+      },
+      "PayloadAttributesV2": {
+        "title": "Payload attributes object V2",
+        "type": "object",
+        "required": ["timestamp", "prevRandao", "suggestedFeeRecipient", "withdrawals"],
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/PayloadAttributesV1/properties/timestamp"
+          },
+          "prevRandao": {
+            "$ref": "#/components/schemas/PayloadAttributesV1/properties/prevRandao"
+          },
+          "suggestedFeeRecipient": {
+            "$ref": "#/components/schemas/PayloadAttributesV1/properties/suggestedFeeRecipient"
+          },
+          "withdrawals": {
+            "title": "Withdrawals",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WithdrawalV1"
+            }
+          }
+        }
+      },
+      "PayloadAttributesV3": {
+        "title": "Payload attributes object V3",
+        "type": "object",
+        "required": ["timestamp", "prevRandao", "suggestedFeeRecipient", "withdrawals", "parentBeaconBlockRoot"],
+        "properties": {
+          "timestamp": {
+            "$ref": "#/components/schemas/PayloadAttributesV2/properties/timestamp"
+          },
+          "prevRandao": {
+            "$ref": "#/components/schemas/PayloadAttributesV2/properties/prevRandao"
+          },
+          "suggestedFeeRecipient": {
+            "$ref": "#/components/schemas/PayloadAttributesV2/properties/suggestedFeeRecipient"
+          },
+          "withdrawals": {
+            "$ref": "#/components/schemas/PayloadAttributesV2/properties/withdrawals"
+          },
+          "parentBeaconBlockRoot": {
+            "title": "Parent beacon block root",
+            "$ref": "#/components/schemas/hash32"
+          }
+        }
+      },
+      "PayloadStatusV1": {
+        "title": "Payload status object V1",
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "title": "Payload validation status",
+            "type": "string",
+            "enum": ["VALID", "INVALID", "SYNCING", "ACCEPTED", "INVALID_BLOCK_HASH"]
+          },
+          "latestValidHash": {
+            "title": "The hash of the most recent valid block",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "validationError": {
+            "title": "Validation error message",
+            "type": "string"
+          }
+        }
+      },
+      "RestrictedPayloadStatusV1": {
+        "$ref": "#/components/schemas/PayloadStatusV1",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/status",
+            "description": "Set of possible values is restricted to VALID, INVALID, SYNCING",
+            "enum": ["VALID", "INVALID", "SYNCING"]
+          },
+          "latestValidHash": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/latestValidHash"
+          },
+          "validationError": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/validationError"
+          }
+        }
+      },
+      "PayloadStatusNoInvalidBlockHash": {
+        "$ref": "#/components/schemas/PayloadStatusV1",
+        "title": "Payload status object deprecating INVALID_BLOCK_HASH status",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/status",
+            "enum": ["VALID", "INVALID", "SYNCING", "ACCEPTED"]
+          },
+          "latestValidHash": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/latestValidHash"
+          },
+          "validationError": {
+            "$ref": "#/components/schemas/PayloadStatusV1/properties/validationError"
+          }
+        }
+      },
+      "ExecutionPayloadV1": {
+        "title": "Execution payload object V1",
+        "type": "object",
+        "required": [
+          "parentHash",
+          "feeRecipient",
+          "stateRoot",
+          "receiptsRoot",
+          "logsBloom",
+          "prevRandao",
+          "blockNumber",
+          "gasLimit",
+          "gasUsed",
+          "timestamp",
+          "extraData",
+          "baseFeePerGas",
+          "blockHash",
+          "transactions"
+        ],
+        "properties": {
+          "parentHash": {
+            "title": "Parent block hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "feeRecipient": {
+            "title": "Recipient of transaction priority fees",
+            "$ref": "#/components/schemas/address"
+          },
+          "stateRoot": {
+            "title": "State root",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "receiptsRoot": {
+            "title": "Receipts root",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "logsBloom": {
+            "title": "Bloom filter",
+            "$ref": "#/components/schemas/bytes256"
+          },
+          "prevRandao": {
+            "title": "Previous randao value",
+            "$ref": "#/components/schemas/bytes32"
+          },
+          "blockNumber": {
+            "title": "Block number",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "gasLimit": {
+            "title": "Gas limit",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "gasUsed": {
+            "title": "Gas used",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "extraData": {
+            "title": "Extra data",
+            "$ref": "#/components/schemas/bytesMax32"
+          },
+          "baseFeePerGas": {
+            "title": "Base fee per gas",
+            "$ref": "#/components/schemas/uint256"
+          },
+          "blockHash": {
+            "title": "Block hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "transactions": {
+            "title": "Transactions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          }
+        }
+      },
+      "WithdrawalV1": {
+        "title": "Withdrawal object V1",
+        "type": "object",
+        "required": ["index", "validatorIndex", "address", "amount"],
+        "properties": {
+          "index": {
+            "title": "Withdrawal index",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "validatorIndex": {
+            "title": "Validator index",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "address": {
+            "title": "Withdrawal address",
+            "$ref": "#/components/schemas/address"
+          },
+          "amount": {
+            "title": "Withdrawal amount",
+            "$ref": "#/components/schemas/uint64"
+          }
+        }
+      },
+      "ExecutionPayloadV2": {
+        "title": "Execution payload object V2",
+        "type": "object",
+        "required": [
+          "parentHash",
+          "feeRecipient",
+          "stateRoot",
+          "receiptsRoot",
+          "logsBloom",
+          "prevRandao",
+          "blockNumber",
+          "gasLimit",
+          "gasUsed",
+          "timestamp",
+          "extraData",
+          "baseFeePerGas",
+          "blockHash",
+          "transactions",
+          "withdrawals"
+        ],
+        "properties": {
+          "parentHash": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/parentHash"
+          },
+          "feeRecipient": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/feeRecipient"
+          },
+          "stateRoot": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/stateRoot"
+          },
+          "receiptsRoot": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/receiptsRoot"
+          },
+          "logsBloom": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/logsBloom"
+          },
+          "prevRandao": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/prevRandao"
+          },
+          "blockNumber": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/blockNumber"
+          },
+          "gasLimit": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/gasLimit"
+          },
+          "gasUsed": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/gasUsed"
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/timestamp"
+          },
+          "extraData": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/extraData"
+          },
+          "baseFeePerGas": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/baseFeePerGas"
+          },
+          "blockHash": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/blockHash"
+          },
+          "transactions": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/transactions"
+          },
+          "withdrawals": {
+            "title": "Withdrawals",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WithdrawalV1"
+            }
+          }
+        }
+      },
+      "ExecutionPayloadV3": {
+        "title": "Execution payload object V3",
+        "type": "object",
+        "required": [
+          "parentHash",
+          "feeRecipient",
+          "stateRoot",
+          "receiptsRoot",
+          "logsBloom",
+          "prevRandao",
+          "blockNumber",
+          "gasLimit",
+          "gasUsed",
+          "timestamp",
+          "extraData",
+          "baseFeePerGas",
+          "blockHash",
+          "transactions",
+          "withdrawals",
+          "blobGasUsed",
+          "excessBlobGas"
+        ],
+        "properties": {
+          "parentHash": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/parentHash"
+          },
+          "feeRecipient": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/feeRecipient"
+          },
+          "stateRoot": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/stateRoot"
+          },
+          "receiptsRoot": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/receiptsRoot"
+          },
+          "logsBloom": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/logsBloom"
+          },
+          "prevRandao": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/prevRandao"
+          },
+          "blockNumber": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/blockNumber"
+          },
+          "gasLimit": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/gasLimit"
+          },
+          "gasUsed": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/gasUsed"
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/timestamp"
+          },
+          "extraData": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/extraData"
+          },
+          "baseFeePerGas": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/baseFeePerGas"
+          },
+          "blockHash": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/blockHash"
+          },
+          "transactions": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/transactions"
+          },
+          "withdrawals": {
+            "$ref": "#/components/schemas/ExecutionPayloadV2/properties/withdrawals"
+          },
+          "blobGasUsed": {
+            "title": "Blob gas used",
+            "$ref": "#/components/schemas/uint64"
+          },
+          "excessBlobGas": {
+            "title": "Excess blob gas",
+            "$ref": "#/components/schemas/uint64"
+          }
+        }
+      },
+      "ExecutionPayloadBodyV1": {
+        "title": "Execution payload body object V1",
+        "type": "object",
+        "required": ["transactions"],
+        "properties": {
+          "transactions": {
+            "$ref": "#/components/schemas/ExecutionPayloadV1/properties/transactions"
+          },
+          "withdrawals": {
+            "title": "Withdrawals",
+            "type": ["array", "null"],
+            "items": {
+              "$ref": "#/components/schemas/WithdrawalV1"
+            }
+          }
+        }
+      },
+      "BlobsBundleV1": {
+        "title": "Blobs bundle object V1",
+        "type": "object",
+        "required": ["commitments", "proofs", "blobs"],
+        "properties": {
+          "commitments": {
+            "title": "Commitments",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes48"
+            }
+          },
+          "proofs": {
+            "title": "Proofs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes48"
+            }
+          },
+          "blobs": {
+            "title": "Blobs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          }
+        }
+      },
+      "BlobsBundleV2": {
+        "title": "Blobs bundle object V2",
+        "type": "object",
+        "required": ["commitments", "proofs", "blobs"],
+        "properties": {
+          "commitments": {
+            "title": "Commitments",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes48"
+            }
+          },
+          "proofs": {
+            "title": "Proofs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes48"
+            }
+          },
+          "blobs": {
+            "title": "Blobs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bytes"
+            }
+          }
+        }
+      },
+      "TransitionConfigurationV1": {
+        "title": "Transition configuration object",
+        "type": "object",
+        "required": ["terminalTotalDifficulty", "terminalBlockHash", "terminalBlockNumber"],
+        "properties": {
+          "terminalTotalDifficulty": {
+            "title": "Terminal total difficulty",
+            "$ref": "#/components/schemas/uint256"
+          },
+          "terminalBlockHash": {
+            "title": "Terminal block hash",
+            "$ref": "#/components/schemas/hash32"
+          },
+          "terminalBlockNumber": {
+            "title": "Terminal block number",
+            "$ref": "#/components/schemas/uint64"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
# OpenRPC JSON Update

This PR updates the OpenRPC JSON file with the latest changes.

## Comparison Report
```

Methods present in the original document but missing from the modified document:

┌─────────┬────────────────────────────────────────────┬───────────────────┐
│ (index) │ missingMethod                              │ status            │
├─────────┼────────────────────────────────────────────┼───────────────────┤
│ 0       │ 'debug_getBadBlocks'                       │ 'not implemented' │
│ 1       │ 'debug_getRawBlock'                        │ 'not implemented' │
│ 2       │ 'debug_getRawHeader'                       │ 'not implemented' │
│ 3       │ 'debug_getRawReceipts'                     │ 'not implemented' │
│ 4       │ 'debug_getRawTransaction'                  │ 'not implemented' │
│ 5       │ 'engine_exchangeCapabilities'              │ 'discarded'       │
│ 6       │ 'engine_exchangeTransitionConfigurationV1' │ 'discarded'       │
│ 7       │ 'engine_forkchoiceUpdatedV1'               │ 'discarded'       │
│ 8       │ 'engine_forkchoiceUpdatedV2'               │ 'discarded'       │
│ 9       │ 'engine_forkchoiceUpdatedV3'               │ 'discarded'       │
│ 10      │ 'engine_getBlobsV1'                        │ 'discarded'       │
│ 11      │ 'engine_getBlobsV2'                        │ 'discarded'       │
│ 12      │ 'engine_getPayloadBodiesByHashV1'          │ 'discarded'       │
│ 13      │ 'engine_getPayloadBodiesByRangeV1'         │ 'discarded'       │
│ 14      │ 'engine_getPayloadV1'                      │ 'discarded'       │
│ 15      │ 'engine_getPayloadV2'                      │ 'discarded'       │
│ 16      │ 'engine_getPayloadV3'                      │ 'discarded'       │
│ 17      │ 'engine_getPayloadV4'                      │ 'discarded'       │
│ 18      │ 'engine_getPayloadV5'                      │ 'discarded'       │
│ 19      │ 'engine_newPayloadV1'                      │ 'discarded'       │
│ 20      │ 'engine_newPayloadV2'                      │ 'discarded'       │
│ 21      │ 'engine_newPayloadV3'                      │ 'discarded'       │
│ 22      │ 'engine_newPayloadV4'                      │ 'discarded'       │
│ 23      │ 'eth_createAccessList'                     │ 'a new method'    │
│ 24      │ 'eth_getBlockReceipts'                     │ 'a new method'    │
└─────────┴────────────────────────────────────────────┴───────────────────┘

Status explanation:
- (discarded): Methods that have been intentionally removed
- (not implemented): Methods that have not been implemented yet

Methods with differences between documents:

┌─────────┬───────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │ method                                    │ valueDiscrepancies                                                              │ customFields                                                                           │
├─────────┼───────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ 0       │ 'eth_accounts'                            │ 'result.schema.title, result.schema.items'                                      │ 'result.schema.pattern, result.description, description'                               │
│ 1       │ 'eth_blobBaseFee'                         │ 'summary, result.name, result.schema'                                           │ 'result.$ref'                                                                          │
│ 2       │ 'eth_blockNumber'                         │ '-'                                                                             │ 'description'                                                                          │
│ 3       │ 'eth_call'                                │ 'summary, params.1.schema.$ref, params.0.schema.$ref'                           │ 'description'                                                                          │
│ 4       │ 'eth_chainId'                             │ '-'                                                                             │ 'description'                                                                          │
│ 5       │ 'eth_coinbase'                            │ 'summary, result.name, result.schema'                                           │ 'result.$ref'                                                                          │
│ 6       │ 'eth_estimateGas'                         │ 'params.0.schema.$ref'                                                          │ 'description'                                                                          │
│ 7       │ 'eth_feeHistory'                          │ 'result (7 diffs), summary, description, params.2.description'                  │ 'result.schema.properties.gasUsedRatio.items (3 diffs), params.2.schema.items.pattern' │
│ 8       │ 'eth_gasPrice'                            │ 'summary'                                                                       │ 'description'                                                                          │
│ 9       │ 'eth_getBalance'                          │ 'params.1.required, params.1.schema.$ref'                                       │ 'result.schema.title, description'                                                     │
│ 10      │ 'eth_getBlockByHash'                      │ 'result.schema.oneOf'                                                           │ 'result.schema.$ref, description'                                                      │
│ 11      │ 'eth_getBlockByNumber'                    │ 'result.schema.oneOf'                                                           │ 'result.schema.$ref, description'                                                      │
│ 12      │ 'eth_getBlockTransactionCountByHash'      │ 'result.name, result.schema.oneOf'                                              │ 'result.schema.$ref, description'                                                      │
│ 13      │ 'eth_getBlockTransactionCountByNumber'    │ 'result.name, result.schema.oneOf'                                              │ 'result.schema.$ref, description'                                                      │
│ 14      │ 'eth_getCode'                             │ 'params.1.required, params.1.schema.$ref'                                       │ 'description'                                                                          │
│ 15      │ 'eth_getFilterChanges'                    │ 'summary, params.0.name, params.0.schema.$ref, result.name, result.schema.$ref' │ 'result.schema.oneOf, description, tags'                                               │
│ 16      │ 'eth_getFilterLogs'                       │ 'summary, params.0.name, params.0.schema.$ref, result.name'                     │ 'description, tags'                                                                    │
│ 17      │ 'eth_getLogs'                             │ 'summary'                                                                       │ 'description'                                                                          │
│ 18      │ 'eth_getProof'                            │ 'summary, params, params, params, result.name, result.schema'                   │ 'result.$ref'                                                                          │
│ 19      │ 'eth_getStorageAt'                        │ 'params (3 diffs), summary, result.name, result.schema.$ref'                    │ 'description'                                                                          │
│ 20      │ 'eth_getTransactionByBlockHashAndIndex'   │ 'result.schema.oneOf'                                                           │ 'result.schema.$ref, description'                                                      │
│ 21      │ 'eth_getTransactionByBlockNumberAndIndex' │ 'result.schema.oneOf'                                                           │ 'result.schema.$ref, description'                                                      │
│ 22      │ 'eth_getTransactionByHash'                │ 'result.schema.oneOf'                                                           │ 'result.schema.$ref, description'                                                      │
│ 23      │ 'eth_getTransactionCount'                 │ 'summary, params.1.required, params.1.schema.$ref, result.name'                 │ 'result.schema.title, description'                                                     │
│ 24      │ 'eth_getTransactionReceipt'               │ 'result.name, result.schema.oneOf'                                              │ 'result.schema.$ref, description'                                                      │
│ 25      │ 'eth_getUncleCountByBlockHash'            │ 'params, result.name, result.schema.oneOf'                                      │ 'result.schema (4 diffs), description'                                                 │
│ 26      │ 'eth_getUncleCountByBlockNumber'          │ 'params, result.name, result.schema.oneOf'                                      │ 'result.schema (4 diffs), description'                                                 │
│ 27      │ 'eth_maxPriorityFeePerGas'                │ 'result (3 diffs), summary'                                                     │ 'result.schema (3 diffs), description'                                                 │
│ 28      │ 'eth_newBlockFilter'                      │ 'summary, result.name, result.schema.$ref'                                      │ 'description, tags'                                                                    │
│ 29      │ 'eth_newFilter'                           │ 'params.0.name, params.0.schema.$ref, result.name, result.schema.$ref'          │ 'description, tags'                                                                    │
│ 30      │ 'eth_newPendingTransactionFilter'         │ 'summary, result.name, result.schema'                                           │ 'result.$ref, tags'                                                                    │
│ 31      │ 'eth_sendRawTransaction'                  │ 'summary'                                                                       │ 'description'                                                                          │
│ 32      │ 'eth_sendTransaction'                     │ 'summary, params, result.name, result.schema'                                   │ 'result.$ref'                                                                          │
│ 33      │ 'eth_sign'                                │ 'summary, params, params, result.name, result.schema'                           │ 'result.$ref'                                                                          │
│ 34      │ 'eth_signTransaction'                     │ 'summary, params, result.name, result.schema'                                   │ 'result.$ref'                                                                          │
│ 35      │ 'eth_syncing'                             │ 'summary, result.schema.$ref'                                                   │ 'result.schema (3 diffs), description'                                                 │
│ 36      │ 'eth_uninstallFilter'                     │ 'params.0.name, params.0.schema.$ref, result.name'                              │ 'description, tags'                                                                    │
└─────────┴───────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────┘

Explanation:
- valueDiscrepancies: Fields that exist in both documents but have different values
- customFields: Fields that exist only in the modified document (custom additions)
- Entries with format "path (N diffs)" indicate N differences within that path
```