### PR TITLE
Update OpenRPC JSON

### DIFF
--- a/scripts/openrpc-json-updater/modified-openrpc.json
+++ b/scripts/openrpc-json-updater/modified-openrpc.json
@@ -59,7 +59,12 @@
         "schema": {
           "title": "empty array",
           "type": "array",
-          "pattern": "^\\[\\s*\\]$"
+          "pattern": "^\\[\\s*\\]$",
+          "items": {
+            "title": "hex encoded address",
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          }
         }
       }
     },
@@ -204,8 +209,6 @@
           "required": ["oldestBlock", "baseFeePerGas", "gasUsedRatio"],
           "properties": {
             "oldestBlock": {
-              "title": "oldestBlock",
-              "description": "Lowest number block of returned range.",
               "$ref": "#/components/schemas/uint"
             },
             "gasUsedRatio": {
@@ -213,9 +216,11 @@
               "description": "An array of gas used ratio.",
               "type": "array",
               "items": {
-                "title": "floating point number",
+                "title": "normalized ratio",
                 "type": "number",
-                "pattern": "^([0-9].[0-9]*|0)$"
+                "pattern": "^([0-9].[0-9]*|0)$",
+                "minimum": 0,
+                "maximum": 1
               }
             },
             "baseFeePerGas": {
@@ -235,13 +240,12 @@
                 "description": "An array of effective priority fee per gas data points from a single block. All zeroes are returned if the block is empty.",
                 "type": "array",
                 "items": {
-                  "title": "rewardPercentile",
-                  "description": "A given percentile sample of effective priority fees per gas from a single block in ascending order, weighted by gas used. Zeroes are returned if the block is empty.",
                   "$ref": "#/components/schemas/uint"
                 }
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -253,7 +257,6 @@
       "result": {
         "name": "Gas price",
         "schema": {
-          "title": "Gas price",
           "$ref": "#/components/schemas/uint"
         }
       }
@@ -272,7 +275,7 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/BlockNumberOrTag"
           }
@@ -281,7 +284,6 @@
       "result": {
         "name": "Balance",
         "schema": {
-          "title": "hex encoded unsigned integer",
           "$ref": "#/components/schemas/uint"
         }
       }
@@ -394,7 +396,7 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/BlockNumberOrTag"
           }
@@ -447,7 +449,7 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
           }
@@ -548,7 +550,7 @@
         },
         {
           "name": "Block",
-          "required": false,
+          "required": true,
           "schema": {
             "$ref": "#/components/schemas/BlockNumberOrTag"
           }
@@ -557,7 +559,6 @@
       "result": {
         "name": "Transaction count",
         "schema": {
-          "title": "Transaction count",
           "$ref": "#/components/schemas/uint"
         }
       }
@@ -575,7 +576,7 @@
         }
       ],
       "result": {
-        "name": "Receipt Information",
+        "name": "Receipt information",
         "schema": {
           "$ref": "#/components/schemas/ReceiptInfo"
         }
@@ -611,14 +612,34 @@
       "name": "eth_getUncleCountByBlockHash",
       "summary": "Returns the number of uncles in a block from a block matching the given block hash.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
-      "params": [],
+      "params": [
+        {
+          "name": "Block hash",
+          "schema": {
+            "title": "32 byte hex value",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          }
+        }
+      ],
       "result": {
-        "name": "eth_getUncleCountByBlockHash result",
+        "name": "Uncle count",
         "schema": {
           "description": "Always returns '0x0'. There are no uncles in Hedera.",
           "title": "hex encoded unsigned integer",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "0x0",
+          "oneOf": [
+            {
+              "title": "Not Found (null)",
+              "type": "null"
+            },
+            {
+              "title": "Uncle count",
+              "type": "string",
+              "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+            }
+          ]
         }
       }
     },
@@ -626,14 +647,45 @@
       "name": "eth_getUncleCountByBlockNumber",
       "summary": "Returns the number of transactions in a block matching the given block number.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
-      "params": [],
+      "params": [
+        {
+          "name": "Block",
+          "schema": {
+            "title": "Block number or tag",
+            "oneOf": [
+              {
+                "title": "Block number",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              {
+                "title": "Block tag",
+                "type": "string",
+                "enum": ["earliest", "finalized", "safe", "latest", "pending"],
+                "description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+              }
+            ]
+          }
+        }
+      ],
       "result": {
-        "name": "eth_getUncleCountByBlockNumber result",
+        "name": "Uncle count",
         "schema": {
           "description": "Always returns '0x0'. There are no uncles in Hedera.",
           "title": "hex encoded unsigned integer",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "0x0",
+          "oneOf": [
+            {
+              "title": "Not Found (null)",
+              "type": "null"
+            },
+            {
+              "title": "Uncle count",
+              "type": "string",
+              "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+            }
+          ]
         }
       }
     },
@@ -665,12 +717,12 @@
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [],
       "result": {
-        "name": "eth_maxPriorityFeePerGas result",
+        "name": "Max priority fee per gas",
         "schema": {
           "description": "Always returns '0x0'. Hedera doesn't have a concept of tipping nodes to promote any behavior",
           "title": "hex encoded unsigned integer",
           "type": "string",
-          "pattern": "0x0"
+          "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
         }
       }
     },
@@ -710,14 +762,14 @@
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
-          "name": "LogFilter",
+          "name": "Filter",
           "schema": {
             "$ref": "#/components/schemas/LogFilter"
           }
         }
       ],
       "result": {
-        "name": "Filter ID",
+        "name": "Filter identifier",
         "schema": {
           "$ref": "#/components/schemas/hash16"
         }
@@ -734,14 +786,14 @@
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "FilterID",
+          "name": "Filter identifier",
           "schema": {
             "$ref": "#/components/schemas/hash16"
           }
         }
       ],
       "result": {
-        "name": "Uninstall status",
+        "name": "Success",
         "schema": {
           "type": "boolean"
         }
@@ -754,7 +806,7 @@
     },
     {
       "name": "eth_newPendingTransactionFilter",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
+      "summary": "Creates a filter in the node, to notify when new pending transactions arrive.",
       "params": [],
       "result": {
         "$ref": "#/components/schemas/unsupportedError"
@@ -767,18 +819,18 @@
     },
     {
       "name": "eth_getFilterLogs",
-      "summary": "Returns an array of all logs matching filter with given id.",
+      "summary": "Returns an array of all logs matching the filter with the given ID (created using `eth_newFilter`).",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "Filter ID",
+          "name": "Filter identifier",
           "schema": {
             "$ref": "#/components/schemas/hash16"
           }
         }
       ],
       "result": {
-        "name": "Filter result",
+        "name": "Log objects",
         "schema": {
           "$ref": "#/components/schemas/FilterResults"
         }
@@ -791,25 +843,24 @@
     },
     {
       "name": "eth_getFilterChanges",
-      "summary": "Gets the latest results since the last request for a provided filter according to its type.",
+      "summary": "Polling method for the filter with the given ID (created using `eth_newFilter`). Returns an array of logs which occurred since last poll.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [
         {
-          "name": "Filter ID",
+          "name": "Filter identifier",
           "schema": {
             "$ref": "#/components/schemas/hash16"
           }
         }
       ],
       "result": {
-        "name": "Filter result",
+        "name": "Log objects",
         "schema": {
           "oneOf": [
             {
               "type": "array",
               "items": {
                 "blockHash": {
-                  "title": "block hash",
                   "$ref": "#/components/schemas/hash32"
                 }
               }
@@ -820,7 +871,8 @@
                 "$ref": "#/components/schemas/FilterResults"
               }
             }
-          ]
+          ],
+          "title": "Filter results"
         }
       },
       "tags": [
@@ -839,7 +891,7 @@
     },
     {
       "name": "eth_sendRawTransaction",
-      "summary": "Submits a raw transaction.",
+      "summary": "Submits a raw transaction. You can create and sign a transaction externally using a library such as [web3.js](https://web3js.readthedocs.io/) or [ethers.js](https://docs.ethers.org/). For [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) transactions, the raw form must be the network form. This means it includes the blobs, KZG commitments, and KZG proofs. For [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594) transactions, the raw format must be the network form. This means it includes the blobs, KZG commitments, and cell proofs. The logic for handling the new transaction during fork boundaries are 1. When receiving an encoded transaction with cell proofs before the PeerDAS fork activates, we reject it. Only blob proofs are accepted into the pool. 2. At the time of fork activation, the implementer could (not mandatory) - Drop all old-format transactions - Convert old proofs to new format (computationally expensive) - Convert only when including in a locally produced block 3. After the fork has activated, only txs with cell proofs are accepted via p2p relay. 4. On RPC (eth_sendRawTransaction), txs with blob proofs may still be accepted and will be auto-converted by the node. At implementer discretion, this facility can be deprecated later when users have switched to new client libraries that can create cell proofs.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/ws_label.png)",
       "params": [
         {
@@ -859,24 +911,393 @@
     },
     {
       "name": "eth_sendTransaction",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Signs and submits a transaction.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "title": "Transaction object generic to all types",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "title": "type",
+                "type": "string",
+                "pattern": "^0x([0-9a-fA-F]?){1,2}$"
+              },
+              "nonce": {
+                "title": "nonce",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "to": {
+                "title": "to address",
+                "oneOf": [
+                  {
+                    "title": "Contract Creation (null)",
+                    "type": "null"
+                  },
+                  {
+                    "title": "Address",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  }
+                ]
+              },
+              "from": {
+                "title": "from address",
+                "type": "string",
+                "pattern": "^0x[0-9a-fA-F]{40}$"
+              },
+              "gas": {
+                "title": "gas limit",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "value": {
+                "title": "value",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "input": {
+                "title": "input data",
+                "type": "string",
+                "pattern": "^0x[0-9a-f]*$"
+              },
+              "gasPrice": {
+                "title": "gas price",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The gas price willing to be paid by the sender in wei"
+              },
+              "maxPriorityFeePerGas": {
+                "title": "max priority fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+              },
+              "maxFeePerGas": {
+                "title": "max fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+              },
+              "maxFeePerBlobGas": {
+                "title": "max fee per blob gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay for blob gas in wei"
+              },
+              "accessList": {
+                "title": "accessList",
+                "type": "array",
+                "description": "EIP-2930 access list",
+                "items": {
+                  "title": "Access list entry",
+                  "type": "object",
+                  "required": ["address", "storageKeys"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "storageKeys": {
+                      "type": "array",
+                      "items": {
+                        "title": "32 byte hex value",
+                        "type": "string",
+                        "pattern": "^0x[0-9a-f]{64}$"
+                      }
+                    }
+                  }
+                }
+              },
+              "blobVersionedHashes": {
+                "title": "blobVersionedHashes",
+                "description": "List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.",
+                "type": "array",
+                "items": {
+                  "title": "32 byte hex value",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]{64}$"
+                }
+              },
+              "blobs": {
+                "title": "blobs",
+                "description": "Raw blob data.",
+                "type": "array",
+                "items": {
+                  "title": "hex encoded bytes",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]*$"
+                }
+              },
+              "chainId": {
+                "title": "chainId",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Chain ID that this transaction is valid on."
+              },
+              "authorizationList": {
+                "title": "authorizationList",
+                "description": "EIP-7702 authorization list",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["chainId", "nonce", "address", "yParity", "r", "s"],
+                  "properties": {
+                    "chainId": {
+                      "title": "chainId",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                      "description": "Chain ID on which this transaction is valid"
+                    },
+                    "nonce": {
+                      "title": "nonce",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                    },
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "yParity": {
+                      "title": "yParity",
+                      "type": "string",
+                      "pattern": "^0x([0-9a-fA-F]?){1,2}$",
+                      "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature"
+                    },
+                    "r": {
+                      "title": "r",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    },
+                    "s": {
+                      "title": "s",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
       "result": {
         "$ref": "#/components/schemas/unsupportedError"
       }
     },
     {
       "name": "eth_signTransaction",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns an RLP encoded transaction signed by the specified account.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "title": "Transaction object generic to all types",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "title": "type",
+                "type": "string",
+                "pattern": "^0x([0-9a-fA-F]?){1,2}$"
+              },
+              "nonce": {
+                "title": "nonce",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "to": {
+                "title": "to address",
+                "oneOf": [
+                  {
+                    "title": "Contract Creation (null)",
+                    "type": "null"
+                  },
+                  {
+                    "title": "Address",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  }
+                ]
+              },
+              "from": {
+                "title": "from address",
+                "type": "string",
+                "pattern": "^0x[0-9a-fA-F]{40}$"
+              },
+              "gas": {
+                "title": "gas limit",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "value": {
+                "title": "value",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "input": {
+                "title": "input data",
+                "type": "string",
+                "pattern": "^0x[0-9a-f]*$"
+              },
+              "gasPrice": {
+                "title": "gas price",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The gas price willing to be paid by the sender in wei"
+              },
+              "maxPriorityFeePerGas": {
+                "title": "max priority fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+              },
+              "maxFeePerGas": {
+                "title": "max fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+              },
+              "maxFeePerBlobGas": {
+                "title": "max fee per blob gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay for blob gas in wei"
+              },
+              "accessList": {
+                "title": "accessList",
+                "type": "array",
+                "description": "EIP-2930 access list",
+                "items": {
+                  "title": "Access list entry",
+                  "type": "object",
+                  "required": ["address", "storageKeys"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "storageKeys": {
+                      "type": "array",
+                      "items": {
+                        "title": "32 byte hex value",
+                        "type": "string",
+                        "pattern": "^0x[0-9a-f]{64}$"
+                      }
+                    }
+                  }
+                }
+              },
+              "blobVersionedHashes": {
+                "title": "blobVersionedHashes",
+                "description": "List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.",
+                "type": "array",
+                "items": {
+                  "title": "32 byte hex value",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]{64}$"
+                }
+              },
+              "blobs": {
+                "title": "blobs",
+                "description": "Raw blob data.",
+                "type": "array",
+                "items": {
+                  "title": "hex encoded bytes",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]*$"
+                }
+              },
+              "chainId": {
+                "title": "chainId",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Chain ID that this transaction is valid on."
+              },
+              "authorizationList": {
+                "title": "authorizationList",
+                "description": "EIP-7702 authorization list",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["chainId", "nonce", "address", "yParity", "r", "s"],
+                  "properties": {
+                    "chainId": {
+                      "title": "chainId",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                      "description": "Chain ID on which this transaction is valid"
+                    },
+                    "nonce": {
+                      "title": "nonce",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                    },
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "yParity": {
+                      "title": "yParity",
+                      "type": "string",
+                      "pattern": "^0x([0-9a-fA-F]?){1,2}$",
+                      "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature"
+                    },
+                    "r": {
+                      "title": "r",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    },
+                    "s": {
+                      "title": "s",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
       "result": {
         "$ref": "#/components/schemas/unsupportedError"
       }
     },
     {
       "name": "eth_sign",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns an EIP-191 signature over the provided data.",
+      "params": [
+        {
+          "name": "Address",
+          "required": true,
+          "schema": {
+            "title": "hex encoded address",
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          }
+        },
+        {
+          "name": "Message",
+          "required": true,
+          "schema": {
+            "title": "hex encoded bytes",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]*$"
+          }
+        }
+      ],
       "result": {
         "$ref": "#/components/schemas/unsupportedError"
       }
@@ -905,15 +1326,44 @@
     },
     {
       "name": "eth_syncing",
-      "summary": "Returns syncing status.",
+      "summary": "Returns an object with data about the sync status or false.",
       "description": "![](https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/docs/images/http_label.png)",
       "params": [],
       "result": {
         "name": "Syncing status",
         "schema": {
-          "title": "Not syncing",
+          "title": "Syncing status",
           "description": "Always returns false.",
-          "type": "boolean"
+          "type": "boolean",
+          "oneOf": [
+            {
+              "title": "Syncing progress",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "startingBlock": {
+                  "title": "Starting block",
+                  "type": "string",
+                  "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                },
+                "currentBlock": {
+                  "title": "Current block",
+                  "type": "string",
+                  "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                },
+                "highestBlock": {
+                  "title": "Highest block",
+                  "type": "string",
+                  "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                }
+              }
+            },
+            {
+              "title": "Not syncing",
+              "description": "Should always return false if not syncing.",
+              "type": "boolean"
+            }
+          ]
         }
       }
     },
@@ -1239,10 +1689,534 @@
     },
     {
       "name": "eth_getProof",
-      "summary": "Always returns UNSUPPORTED_METHOD error.",
-      "params": [],
+      "summary": "Returns the merkle proof for a given account and optionally some storage keys.",
+      "params": [
+        {
+          "name": "Address",
+          "required": true,
+          "schema": {
+            "title": "hex encoded address",
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          }
+        },
+        {
+          "name": "StorageKeys",
+          "required": true,
+          "schema": {
+            "title": "Storage keys",
+            "type": "array",
+            "items": {
+              "title": "32 hex encoded bytes",
+              "type": "string",
+              "pattern": "^0x[0-9a-f]{0,64}$"
+            }
+          }
+        },
+        {
+          "name": "Block",
+          "required": true,
+          "schema": {
+            "title": "Block number, tag, or block hash",
+            "anyOf": [
+              {
+                "title": "Block number",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              {
+                "title": "Block tag",
+                "type": "string",
+                "enum": ["earliest", "finalized", "safe", "latest", "pending"],
+                "description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+              },
+              {
+                "title": "Block hash",
+                "type": "string",
+                "pattern": "^0x[0-9a-f]{64}$"
+              }
+            ]
+          }
+        }
+      ],
       "result": {
         "$ref": "#/components/schemas/unsupportedError"
+      }
+    },
+    {
+      "name": "eth_createAccessList",
+      "summary": "Generates an access list for a transaction.",
+      "params": [
+        {
+          "name": "Transaction",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "title": "Transaction object generic to all types",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "title": "type",
+                "type": "string",
+                "pattern": "^0x([0-9a-fA-F]?){1,2}$"
+              },
+              "nonce": {
+                "title": "nonce",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "to": {
+                "title": "to address",
+                "oneOf": [
+                  {
+                    "title": "Contract Creation (null)",
+                    "type": "null"
+                  },
+                  {
+                    "title": "Address",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  }
+                ]
+              },
+              "from": {
+                "title": "from address",
+                "type": "string",
+                "pattern": "^0x[0-9a-fA-F]{40}$"
+              },
+              "gas": {
+                "title": "gas limit",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "value": {
+                "title": "value",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              "input": {
+                "title": "input data",
+                "type": "string",
+                "pattern": "^0x[0-9a-f]*$"
+              },
+              "gasPrice": {
+                "title": "gas price",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The gas price willing to be paid by the sender in wei"
+              },
+              "maxPriorityFeePerGas": {
+                "title": "max priority fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+              },
+              "maxFeePerGas": {
+                "title": "max fee per gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+              },
+              "maxFeePerBlobGas": {
+                "title": "max fee per blob gas",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "The maximum total fee per gas the sender is willing to pay for blob gas in wei"
+              },
+              "accessList": {
+                "title": "accessList",
+                "type": "array",
+                "description": "EIP-2930 access list",
+                "items": {
+                  "title": "Access list entry",
+                  "type": "object",
+                  "required": ["address", "storageKeys"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "storageKeys": {
+                      "type": "array",
+                      "items": {
+                        "title": "32 byte hex value",
+                        "type": "string",
+                        "pattern": "^0x[0-9a-f]{64}$"
+                      }
+                    }
+                  }
+                }
+              },
+              "blobVersionedHashes": {
+                "title": "blobVersionedHashes",
+                "description": "List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.",
+                "type": "array",
+                "items": {
+                  "title": "32 byte hex value",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]{64}$"
+                }
+              },
+              "blobs": {
+                "title": "blobs",
+                "description": "Raw blob data.",
+                "type": "array",
+                "items": {
+                  "title": "hex encoded bytes",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]*$"
+                }
+              },
+              "chainId": {
+                "title": "chainId",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                "description": "Chain ID that this transaction is valid on."
+              },
+              "authorizationList": {
+                "title": "authorizationList",
+                "description": "EIP-7702 authorization list",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["chainId", "nonce", "address", "yParity", "r", "s"],
+                  "properties": {
+                    "chainId": {
+                      "title": "chainId",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                      "description": "Chain ID on which this transaction is valid"
+                    },
+                    "nonce": {
+                      "title": "nonce",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                    },
+                    "address": {
+                      "title": "hex encoded address",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-fA-F]{40}$"
+                    },
+                    "yParity": {
+                      "title": "yParity",
+                      "type": "string",
+                      "pattern": "^0x([0-9a-fA-F]?){1,2}$",
+                      "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature"
+                    },
+                    "r": {
+                      "title": "r",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    },
+                    "s": {
+                      "title": "s",
+                      "type": "string",
+                      "pattern": "^0x(0|[1-9a-f][0-9a-f]{0,63})$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "Block",
+          "required": false,
+          "schema": {
+            "title": "Block number or tag",
+            "oneOf": [
+              {
+                "title": "Block number",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              {
+                "title": "Block tag",
+                "type": "string",
+                "enum": ["earliest", "finalized", "safe", "latest", "pending"],
+                "description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "Gas used",
+        "schema": {
+          "title": "Access list result",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accessList": {
+              "title": "accessList",
+              "type": "array",
+              "items": {
+                "title": "Access list entry",
+                "type": "object",
+                "required": ["address", "storageKeys"],
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "title": "hex encoded address",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  },
+                  "storageKeys": {
+                    "type": "array",
+                    "items": {
+                      "title": "32 byte hex value",
+                      "type": "string",
+                      "pattern": "^0x[0-9a-f]{64}$"
+                    }
+                  }
+                }
+              }
+            },
+            "error": {
+              "title": "error",
+              "type": "string"
+            },
+            "gasUsed": {
+              "title": "Gas used",
+              "type": "string",
+              "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "eth_getBlockReceipts",
+      "summary": "Returns the receipts of a block by number or hash.",
+      "params": [
+        {
+          "name": "Block",
+          "required": true,
+          "schema": {
+            "title": "Block number, tag, or block hash",
+            "anyOf": [
+              {
+                "title": "Block number",
+                "type": "string",
+                "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+              },
+              {
+                "title": "Block tag",
+                "type": "string",
+                "enum": ["earliest", "finalized", "safe", "latest", "pending"],
+                "description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+              },
+              {
+                "title": "Block hash",
+                "type": "string",
+                "pattern": "^0x[0-9a-f]{64}$"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "Receipts information",
+        "schema": {
+          "oneOf": [
+            {
+              "title": "Not Found (null)",
+              "type": "null"
+            },
+            {
+              "title": "Receipts information",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "title": "Receipt information",
+                "required": [
+                  "blockHash",
+                  "blockNumber",
+                  "from",
+                  "cumulativeGasUsed",
+                  "gasUsed",
+                  "logs",
+                  "logsBloom",
+                  "transactionHash",
+                  "transactionIndex",
+                  "effectiveGasPrice"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "type": {
+                    "title": "type",
+                    "type": "string",
+                    "pattern": "^0x([0-9a-fA-F]?){1,2}$"
+                  },
+                  "transactionHash": {
+                    "title": "transaction hash",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{64}$"
+                  },
+                  "transactionIndex": {
+                    "title": "transaction index",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                  },
+                  "blockHash": {
+                    "title": "block hash",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{64}$"
+                  },
+                  "blockNumber": {
+                    "title": "block number",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                  },
+                  "from": {
+                    "title": "from",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  },
+                  "to": {
+                    "title": "to",
+                    "description": "Address of the receiver or null in a contract creation transaction.",
+                    "oneOf": [
+                      {
+                        "title": "Contract Creation (null)",
+                        "type": "null"
+                      },
+                      {
+                        "title": "Recipient Address",
+                        "type": "string",
+                        "pattern": "^0x[0-9a-fA-F]{40}$"
+                      }
+                    ]
+                  },
+                  "cumulativeGasUsed": {
+                    "title": "cumulative gas used",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "The sum of gas used by this transaction and all preceding transactions in the same block."
+                  },
+                  "gasUsed": {
+                    "title": "gas used",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "The amount of gas used for this specific transaction alone."
+                  },
+                  "blobGasUsed": {
+                    "title": "blob gas used",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "The amount of blob gas used for this specific transaction. Only specified for blob transactions as defined by EIP-4844."
+                  },
+                  "contractAddress": {
+                    "title": "contract address",
+                    "description": "The contract address created, if the transaction was a contract creation, otherwise null.",
+                    "oneOf": [
+                      {
+                        "title": "hex encoded address",
+                        "type": "string",
+                        "pattern": "^0x[0-9a-fA-F]{40}$"
+                      },
+                      {
+                        "title": "Null",
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "logs": {
+                    "title": "logs",
+                    "type": "array",
+                    "items": {
+                      "title": "log",
+                      "type": "object",
+                      "required": ["transactionHash"],
+                      "additionalProperties": false,
+                      "properties": {
+                        "removed": {
+                          "title": "removed",
+                          "type": "boolean"
+                        },
+                        "logIndex": {
+                          "title": "log index",
+                          "type": "string",
+                          "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                        },
+                        "transactionIndex": {
+                          "title": "transaction index",
+                          "type": "string",
+                          "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                        },
+                        "transactionHash": {
+                          "title": "transaction hash",
+                          "type": "string",
+                          "pattern": "^0x[0-9a-f]{64}$"
+                        },
+                        "blockHash": {
+                          "title": "block hash",
+                          "type": "string",
+                          "pattern": "^0x[0-9a-f]{64}$"
+                        },
+                        "blockNumber": {
+                          "title": "block number",
+                          "type": "string",
+                          "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$"
+                        },
+                        "address": {
+                          "title": "address",
+                          "type": "string",
+                          "pattern": "^0x[0-9a-fA-F]{40}$"
+                        },
+                        "data": {
+                          "title": "data",
+                          "type": "string",
+                          "pattern": "^0x[0-9a-f]*$"
+                        },
+                        "topics": {
+                          "title": "topics",
+                          "type": "array",
+                          "items": {
+                            "title": "32 hex encoded bytes",
+                            "type": "string",
+                            "pattern": "^0x[0-9a-f]{64}$"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "logsBloom": {
+                    "title": "logs bloom",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{512}$"
+                  },
+                  "root": {
+                    "title": "state root",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{64}$",
+                    "description": "The post-transaction state root. Only specified for transactions included before the Byzantium upgrade."
+                  },
+                  "status": {
+                    "title": "status",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade."
+                  },
+                  "effectiveGasPrice": {
+                    "title": "effective gas price",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "The actual value per gas deducted from the sender's account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas)."
+                  },
+                  "blobGasPrice": {
+                    "title": "blob gas price",
+                    "type": "string",
+                    "pattern": "^0x(0|[1-9a-f][0-9a-f]*)$",
+                    "description": "The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844."
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     }
   ],


### PR DESCRIPTION
# OpenRPC JSON Update

This PR updates the OpenRPC JSON file with the latest changes.

## Comparison Report
```

Methods present in the original document but missing from the modified document:

┌─────────┬────────────────────────────────────────────┬───────────────────┐
│ (index) │ missingMethod                              │ status            │
├─────────┼────────────────────────────────────────────┼───────────────────┤
│ 0       │ 'debug_getBadBlocks'                       │ 'not implemented' │
│ 1       │ 'debug_getRawBlock'                        │ 'not implemented' │
│ 2       │ 'debug_getRawHeader'                       │ 'not implemented' │
│ 3       │ 'debug_getRawReceipts'                     │ 'not implemented' │
│ 4       │ 'debug_getRawTransaction'                  │ 'not implemented' │
│ 5       │ 'engine_exchangeCapabilities'              │ 'discarded'       │
│ 6       │ 'engine_exchangeTransitionConfigurationV1' │ 'discarded'       │
│ 7       │ 'engine_forkchoiceUpdatedV1'               │ 'discarded'       │
│ 8       │ 'engine_forkchoiceUpdatedV2'               │ 'discarded'       │
│ 9       │ 'engine_forkchoiceUpdatedV3'               │ 'discarded'       │
│ 10      │ 'engine_getBlobsV1'                        │ 'discarded'       │
│ 11      │ 'engine_getBlobsV2'                        │ 'discarded'       │
│ 12      │ 'engine_getPayloadBodiesByHashV1'          │ 'discarded'       │
│ 13      │ 'engine_getPayloadBodiesByRangeV1'         │ 'discarded'       │
│ 14      │ 'engine_getPayloadV1'                      │ 'discarded'       │
│ 15      │ 'engine_getPayloadV2'                      │ 'discarded'       │
│ 16      │ 'engine_getPayloadV3'                      │ 'discarded'       │
│ 17      │ 'engine_getPayloadV4'                      │ 'discarded'       │
│ 18      │ 'engine_getPayloadV5'                      │ 'discarded'       │
│ 19      │ 'engine_newPayloadV1'                      │ 'discarded'       │
│ 20      │ 'engine_newPayloadV2'                      │ 'discarded'       │
│ 21      │ 'engine_newPayloadV3'                      │ 'discarded'       │
│ 22      │ 'engine_newPayloadV4'                      │ 'discarded'       │
│ 23      │ 'eth_createAccessList'                     │ 'a new method'    │
│ 24      │ 'eth_getBlockReceipts'                     │ 'a new method'    │
└─────────┴────────────────────────────────────────────┴───────────────────┘

Status explanation:
- (discarded): Methods that have been intentionally removed
- (not implemented): Methods that have not been implemented yet

Methods with differences between documents:

┌─────────┬───────────────────────────────────────────┬─────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────┐
│ (index) │ method                                    │ valueDiscrepancies                                              │ customFields                                                                  │
├─────────┼───────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────┤
│ 0       │ 'eth_accounts'                            │ 'result.schema.title, result.schema.items'                      │ 'result.schema.pattern, result.description, description'                      │
│ 1       │ 'eth_blobBaseFee'                         │ 'summary, result.name, result.schema'                           │ 'result.$ref'                                                                 │
│ 2       │ 'eth_blockNumber'                         │ 'result.schema (3 diffs)'                                       │ 'result.schema.$ref, description'                                             │
│ 3       │ 'eth_call'                                │ 'result.schema (3 diffs), summary'                              │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 4       │ 'eth_chainId'                             │ 'result.schema (3 diffs)'                                       │ 'result.schema.$ref, description'                                             │
│ 5       │ 'eth_coinbase'                            │ 'summary, result.name, result.schema'                           │ 'result.$ref'                                                                 │
│ 6       │ 'eth_estimateGas'                         │ 'result.schema (3 diffs)'                                       │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 7       │ 'eth_feeHistory'                          │ 'result (16 diffs), summary, description, params.2.description' │ 'result.schema.properties (4 diffs), params (3 diffs)'                        │
│ 8       │ 'eth_gasPrice'                            │ 'summary, result.schema.type, result.schema.pattern'            │ 'result.schema.$ref, description'                                             │
│ 9       │ 'eth_getBalance'                          │ 'params.1.required, result.schema.type, result.schema.pattern'  │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 10      │ 'eth_getBlockByHash'                      │ 'result.schema.oneOf'                                           │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 11      │ 'eth_getBlockByNumber'                    │ 'result.schema.oneOf'                                           │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 12      │ 'eth_getBlockTransactionCountByHash'      │ 'result.name, result.schema.oneOf'                              │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 13      │ 'eth_getBlockTransactionCountByNumber'    │ 'result.name, result.schema.oneOf'                              │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 14      │ 'eth_getCode'                             │ 'result.schema (3 diffs), params.1.required'                    │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 15      │ 'eth_getFilterChanges'                    │ 'summary, params.0.name, result.name, result.schema.title'      │ 'result.schema.oneOf (3 diffs), params.0.schema.$ref, description, tags'      │
│ 16      │ 'eth_getFilterLogs'                       │ 'result (3 diffs), summary, params.0.name'                      │ 'params.0.schema.$ref, result.schema.$ref, description, tags'                 │
│ 17      │ 'eth_getLogs'                             │ 'summary, result.schema.title, result.schema.oneOf'             │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 18      │ 'eth_getProof'                            │ 'summary, params, params, params, result.name, result.schema'   │ 'result.$ref'                                                                 │
│ 19      │ 'eth_getStorageAt'                        │ 'result (4 diffs), summary, params.2.required, params.1.name'   │ 'params (3 diffs), result.schema.$ref, description'                           │
│ 20      │ 'eth_getTransactionByBlockHashAndIndex'   │ 'result.schema.oneOf'                                           │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 21      │ 'eth_getTransactionByBlockNumberAndIndex' │ 'result.schema.oneOf'                                           │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 22      │ 'eth_getTransactionByHash'                │ 'result.schema.oneOf'                                           │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 23      │ 'eth_getTransactionCount'                 │ 'result (4 diffs), summary, params.1.required'                  │ 'params.1.schema.$ref, params.0.schema.$ref, result.schema.$ref, description' │
│ 24      │ 'eth_getTransactionReceipt'               │ 'result.name, result.schema.oneOf'                              │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 25      │ 'eth_getUncleCountByBlockHash'            │ 'params, result.name, result.schema.oneOf'                      │ 'result.schema (4 diffs), description'                                        │
│ 26      │ 'eth_getUncleCountByBlockNumber'          │ 'params, result.name, result.schema.oneOf'                      │ 'result.schema (4 diffs), description'                                        │
│ 27      │ 'eth_maxPriorityFeePerGas'                │ 'result (3 diffs), summary'                                     │ 'result.schema.description, description'                                      │
│ 28      │ 'eth_newBlockFilter'                      │ 'result (4 diffs), summary'                                     │ 'result.schema.$ref, description, tags'                                       │
│ 29      │ 'eth_newFilter'                           │ 'result (4 diffs), params.0.name'                               │ 'params.0.schema.$ref, result.schema.$ref, description, tags'                 │
│ 30      │ 'eth_newPendingTransactionFilter'         │ 'summary, result.name, result.schema'                           │ 'result.$ref, tags'                                                           │
│ 31      │ 'eth_sendRawTransaction'                  │ 'result.schema (3 diffs), summary'                              │ 'params.0.schema.$ref, result.schema.$ref, description'                       │
│ 32      │ 'eth_sendTransaction'                     │ 'summary, params, result.name, result.schema'                   │ 'result.$ref'                                                                 │
│ 33      │ 'eth_sign'                                │ 'summary, params, params, result.name, result.schema'           │ 'result.$ref'                                                                 │
│ 34      │ 'eth_signTransaction'                     │ 'summary, params, result.name, result.schema'                   │ 'result.$ref'                                                                 │
│ 35      │ 'eth_syncing'                             │ 'summary, result.schema.title, result.schema.oneOf'             │ 'result.schema.description, result.schema.type, description'                  │
│ 36      │ 'eth_uninstallFilter'                     │ 'params.0.name, result.name'                                    │ 'params.0.schema.$ref, description, tags'                                     │
└─────────┴───────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────┘

Explanation:
- valueDiscrepancies: Fields that exist in both documents but have different values
- customFields: Fields that exist only in the modified document (custom additions)
- Entries with format "path (N diffs)" indicate N differences within that path
```